### PR TITLE
Converts recent V1 lab templates into Manta-compatible format

### DIFF
--- a/lab/image_classification.yml
+++ b/lab/image_classification.yml
@@ -6,13 +6,13 @@ type: lab
 version: "1.0"
 env:
   image: myelintek/classification:1.0
+  volumes:
+    - mnist:/mlsteam/data
   requirements:
     gpu: 1
 hashtag:
   - image classification
   - tensorflow
-volumes:
-  - mnist:/mlsteam/data
 runtime_params:
   command: python2 trainer.py
   params_definition:

--- a/lab/monai_bundle_lab.yml
+++ b/lab/monai_bundle_lab.yml
@@ -3,12 +3,16 @@ author: MLSteam
 description: |
   Based on monailabel 0.7.0 with monai bundle app
   Including breast_density_classification example
+format: v2
+type: lab
 version: "1.0"
-image: myelintek/monai-bundle-lab:1.0
-gpu: 0
+env:
+  image: myelintek/monai-bundle-lab:1.0
+  volumes:
+    - data:/data
+    - models:/models
+  requirements:
+    gpu: 0
 hashtag:
   - pytorch
   - fastai
-volumes:
-  - data:/data
-  - models:/models

--- a/lab/monai_core.yml
+++ b/lab/monai_core.yml
@@ -1,9 +1,13 @@
 name: MONAI-core
 author: MLSteam
 description: Medical Open Network for Artificial Intelligence
+format: v2
+type: lab
 version: "1.1.0"
-image: myelintek/monai:1.1.0
-gpu: 1
+env:
+  image: myelintek/monai:1.1.0
+  requirements:
+    gpu: 1
 hashtag:
   - monai
   - pytorch

--- a/lab/pytorch_cifar10.yml
+++ b/lab/pytorch_cifar10.yml
@@ -1,14 +1,18 @@
 name: Pytorch Cifar10
 author: MLSteam
 description: Cifar10 in Pytorch
+format: v2
+type: lab
 version: "1.0.2"
-image: myelintek/pytorch-cifar10:1.0.2
-gpu: 1
+env:
+  image: myelintek/pytorch-cifar10:1.0.2
+  volumes:
+    - cifar10:/mlsteam/data/cifar10
+  requirements:
+    gpu: 1
 hashtag:
   - classification
   - pytorch
-volumes:
-  - cifar10:/mlsteam/data/cifar10
 runtime_params:
   command: python train.py
   params:

--- a/lab/pytorch_fastai.yml
+++ b/lab/pytorch_fastai.yml
@@ -3,9 +3,13 @@ author: MLSteam
 description: |
   Based on Nvidia PyTorch release 22.08 (which pytorch version 1.13.0a0+d321be6)
   Including fastai and tabular example.
+format: v2
+type: lab
 version: "1.0"
-image: myelintek/pytorch-fastai:1.0
-gpu: 0
+env:
+  image: myelintek/pytorch-fastai:1.0
+  requirements:
+    gpu: 0
 hashtag:
   - pytorch
   - fastai


### PR DESCRIPTION
Now, we can install datasets by installing lab templates.

Fixes myelintek/Manta#50

![image](https://github.com/user-attachments/assets/148dafcc-e398-4c01-9671-2030246cd183)
